### PR TITLE
chore: アプリ名表示設定の最適化 (#43)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -64,6 +64,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.RRRRRRR777.TokoToko
         INFOPLIST_KEY_CFBundleDisplayName: "とことこ"
+        INFOPLIST_KEY_CFBundleName: "とことこ - お散歩SNS"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES


### PR DESCRIPTION
  - CFBundleDisplayNameをホーム画面用に「とことこ」に設定
  - CFBundleNameをApp Store/設定用に「とことこ - お散歩SNS」に追加

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>
(#45)