### PR TITLE
WalkHistoryViewのUIテスト失敗を解決 (#55)

### DIFF
--- a/TokoToko/Model/Services/WalkRepository.swift
+++ b/TokoToko/Model/Services/WalkRepository.swift
@@ -87,8 +87,8 @@ class WalkRepository {
       operation: "configureFirestore",
       message: "Firestore設定完了",
       context: [
-        "persistence_enabled": "true", // PersistentCacheSettings.unlimited を使用しているため常にtrue
-        "cache_size_bytes": "unlimited", // PersistentCacheSettings.unlimited を使用しているため
+        "persistence_enabled": "true",  // PersistentCacheSettings.unlimited を使用しているため常にtrue
+        "cache_size_bytes": "unlimited",  // PersistentCacheSettings.unlimited を使用しているため
       ]
     )
   }
@@ -98,6 +98,17 @@ class WalkRepository {
   // すべてのWalkを取得（現在のユーザーのみ）
   func fetchWalks(completion: @escaping (Result<[Walk], WalkRepositoryError>) -> Void) {
     logger.logMethodStart()
+
+    // UIテストモード時は空のリストを返す
+    if UITestingHelper.shared.isUITesting {
+      logger.info(
+        operation: "fetchWalks",
+        message: "UIテストモード: 空のWalkリストを返します",
+        context: ["ui_testing": "true"]
+      )
+      completion(.success([]))
+      return
+    }
 
     // 認証済みユーザーIDが必要
     guard let userId = getCurrentUserId() else {
@@ -369,9 +380,9 @@ class WalkRepository {
     ])
 
     logger.logFirebaseSyncBugPrevention(
-      isOnline: true, // 仮定
-      pendingWrites: 0, // 仮定
-      lastSync: Date(), // 仮定
+      isOnline: true,  // 仮定
+      pendingWrites: 0,  // 仮定
+      lastSync: Date(),  // 仮定
       context: [
         "walk_id": walk.id.uuidString,
         "collection": collectionName,
@@ -444,9 +455,9 @@ class WalkRepository {
     ])
 
     logger.logFirebaseSyncBugPrevention(
-      isOnline: true, // 仮定
-      pendingWrites: 0, // 仮定
-      lastSync: Date(), // 仮定
+      isOnline: true,  // 仮定
+      pendingWrites: 0,  // 仮定
+      lastSync: Date(),  // 仮定
       context: [
         "user_id": userId,
         "collection": collectionName,
@@ -553,9 +564,9 @@ class WalkRepository {
     }
 
     logger.logFirebaseSyncBugPrevention(
-      isOnline: true, // 仮定
-      pendingWrites: 0, // 仮定
-      lastSync: Date(), // 仮定
+      isOnline: true,  // 仮定
+      pendingWrites: 0,  // 仮定
+      lastSync: Date(),  // 仮定
       context: [
         "walk_id": walk.id.uuidString,
         "collection": collectionName,
@@ -613,9 +624,9 @@ class WalkRepository {
     ])
 
     logger.logFirebaseSyncBugPrevention(
-      isOnline: true, // 仮定
-      pendingWrites: 0, // 仮定
-      lastSync: Date(), // 仮定
+      isOnline: true,  // 仮定
+      pendingWrites: 0,  // 仮定
+      lastSync: Date(),  // 仮定
       context: [
         "walk_id": walkId.uuidString,
         "collection": collectionName,

--- a/TokoToko/Model/Testing/TestingProtocols.swift
+++ b/TokoToko/Model/Testing/TestingProtocols.swift
@@ -35,16 +35,24 @@ public class ProductionUITestingProvider: UITestingProvider {
 /// UIテスト環境用のUIテストプロバイダー実装
 public class UITestUITestingProvider: UITestingProvider {
   public var isUITesting: Bool { true }
-  public var isMockLoggedIn: Bool { ProcessInfo.processInfo.arguments.contains("--logged-in") }
+  public var isMockLoggedIn: Bool {
+    let args = ProcessInfo.processInfo.arguments
+    return args.contains("--logged-in") || args.contains("MOCK_LOGGED_IN")
+  }
   public var hasDeepLink: Bool {
     let args = ProcessInfo.processInfo.arguments
     return args.contains("--deep-link") || args.contains("--destination")
+      || args.contains(where: { $0.hasPrefix("DEEP_LINK_DESTINATION_") })
   }
 
   public var deepLinkDestination: String? {
     let args = ProcessInfo.processInfo.arguments
     if let index = args.firstIndex(of: "--destination"), index + 1 < args.count {
       return args[index + 1]
+    }
+    // DEEP_LINK_DESTINATION_walk 形式の引数を探す
+    if let deepLinkArg = args.first(where: { $0.hasPrefix("DEEP_LINK_DESTINATION_") }) {
+      return String(deepLinkArg.dropFirst("DEEP_LINK_DESTINATION_".count))
     }
     return nil
   }

--- a/TokoToko/Model/Testing/UITestingHelper.swift
+++ b/TokoToko/Model/Testing/UITestingHelper.swift
@@ -18,7 +18,8 @@ public class UITestingHelper {
 
   /// 初期化時にUIテストモードかどうかを判定し、適切なプロバイダーを設定
   private init() {
-    let isUITesting = ProcessInfo.processInfo.arguments.contains("--uitesting")
+    let args = ProcessInfo.processInfo.arguments
+    let isUITesting = args.contains("--uitesting") || args.contains("UI_TESTING")
     provider = isUITesting ? UITestUITestingProvider() : ProductionUITestingProvider()
   }
 

--- a/TokoToko/View/Screens/WalkHistoryView.swift
+++ b/TokoToko/View/Screens/WalkHistoryView.swift
@@ -19,11 +19,14 @@ struct WalkHistoryView: View {
       // セグメントコントロール
       Picker("履歴タブ", selection: $selectedTab) {
         Text("自分の履歴").tag(0)
+          .accessibilityIdentifier("自分の履歴")
         Text("フレンドの履歴").tag(1)
+          .accessibilityIdentifier("フレンドの履歴")
       }
       .pickerStyle(SegmentedPickerStyle())
       .padding(.horizontal)
       .padding(.top, 8)
+      .accessibilityIdentifier("履歴タブSegmentedControl")
 
       // タブコンテンツ
       TabView(selection: $selectedTab) {
@@ -98,16 +101,19 @@ struct WalkHistoryView: View {
       Image(systemName: "figure.walk.circle")
         .font(.system(size: 60))
         .foregroundColor(.gray)
+        .accessibilityIdentifier("空の散歩履歴アイコン")
 
       Text("散歩履歴がありません")
         .font(.title2)
         .fontWeight(.semibold)
+        .accessibilityIdentifier("散歩履歴がありません")
 
       Text("散歩を完了すると、ここに履歴が表示されます")
         .font(.body)
         .foregroundColor(.gray)
         .multilineTextAlignment(.center)
         .padding(.horizontal)
+        .accessibilityIdentifier("散歩を完了すると、ここに履歴が表示されます")
 
       Spacer()
     }

--- a/TokoTokoUITests/WalkHistoryViewUITests.swift
+++ b/TokoTokoUITests/WalkHistoryViewUITests.swift
@@ -8,210 +8,212 @@
 import XCTest
 
 final class WalkHistoryViewUITests: XCTestCase {
-    
-    var app: XCUIApplication!
-    
-    override func setUpWithError() throws {
-        continueAfterFailure = false
-        app = XCUIApplication()
-        
-        // UIテストモードを有効化
-        app.launchArguments.append("UI_TESTING")
-        app.launchArguments.append("MOCK_LOGGED_IN")
-        
-        // おさんぽタブへのディープリンクを設定
-        app.launchArguments.append("DEEP_LINK_DESTINATION_walk")
-        
-        app.launch()
+
+  var app: XCUIApplication!
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    app = XCUIApplication()
+
+    // UIテストモードを有効化
+    app.launchArguments.append("UI_TESTING")
+    app.launchArguments.append("MOCK_LOGGED_IN")
+
+    // おさんぽタブへのディープリンクを設定
+    app.launchArguments.append("DEEP_LINK_DESTINATION_walk")
+
+    app.launch()
+  }
+
+  override func tearDownWithError() throws {
+    app = nil
+  }
+
+  // MARK: - 基本ナビゲーションテスト
+
+  func testWalkHistoryViewBasicNavigation() throws {
+    // Given: アプリが起動している
+
+    // When: おさんぽタブが表示される
+    let friendTab = app.buttons["おさんぽ"]
+    XCTAssertTrue(friendTab.exists)
+
+    // Then: おさんぽタブが選択状態になっている
+    XCTAssertTrue(friendTab.isSelected)
+  }
+
+  func testWalkHistoryViewNavigationTitle() throws {
+    // Given: おさんぽタブが表示されている
+
+    // When: ナビゲーションタイトルを確認
+    let navigationTitle = app.navigationBars["おさんぽ"]
+
+    // Then: 正しいタイトルが表示されている
+    XCTAssertTrue(navigationTitle.exists)
+  }
+
+  // MARK: - セグメントコントロールテスト
+
+  func testSegmentedControlExists() throws {
+    // Given: WalkHistoryViewが表示されている
+
+    // When: セグメントコントロールを探す
+    let segmentedControl = app.segmentedControls.firstMatch
+
+    // Then: セグメントコントロールが存在する
+    XCTAssertTrue(segmentedControl.exists)
+  }
+
+  func testSegmentedControlOptions() throws {
+    // Given: WalkHistoryViewが表示されている
+
+    // When: セグメントコントロールのボタンを確認
+    let myHistoryButton = app.buttons["自分の履歴"]
+    let friendHistoryButton = app.buttons["フレンドの履歴"]
+
+    // Then: 両方のオプションが存在する
+    XCTAssertTrue(myHistoryButton.exists)
+    XCTAssertTrue(friendHistoryButton.exists)
+  }
+
+  func testSegmentedControlTapping() throws {
+    // Given: WalkHistoryViewが表示されている
+    let myHistoryButton = app.buttons["自分の履歴"]
+    let friendHistoryButton = app.buttons["フレンドの履歴"]
+
+    // When: 「自分の履歴」が最初に選択されている
+    XCTAssertTrue(myHistoryButton.isSelected)
+    XCTAssertFalse(friendHistoryButton.isSelected)
+
+    // When: 「フレンドの履歴」をタップ
+    friendHistoryButton.tap()
+
+    // Then: 選択状態が変更される
+    XCTAssertFalse(myHistoryButton.isSelected)
+    XCTAssertTrue(friendHistoryButton.isSelected)
+
+    // When: 「自分の履歴」に戻る
+    myHistoryButton.tap()
+
+    // Then: 元の状態に戻る
+    XCTAssertTrue(myHistoryButton.isSelected)
+    XCTAssertFalse(friendHistoryButton.isSelected)
+  }
+
+  // MARK: - 自分の履歴タブテスト
+
+  func testMyWalkHistoryEmptyState() throws {
+    // Given: 自分の履歴タブが選択されている
+    let myHistoryButton = app.buttons["自分の履歴"]
+    myHistoryButton.tap()
+
+    // When: 空の状態を確認
+    let emptyMessage = app.staticTexts["散歩履歴がありません"]
+    let emptyDescription = app.staticTexts["散歩を完了すると、ここに履歴が表示されます"]
+
+    // Then: 空の状態メッセージが表示される
+    XCTAssertTrue(emptyMessage.exists)
+    XCTAssertTrue(emptyDescription.exists)
+  }
+
+  func testMyWalkHistoryLoadingState() throws {
+    // Given: 自分の履歴タブが選択されている
+    let myHistoryButton = app.buttons["自分の履歴"]
+    myHistoryButton.tap()
+
+    // When: 読み込み状態を確認（短時間のため、すばやく確認）
+    let loadingIndicator = app.activityIndicators.firstMatch
+
+    // Then: ローディングインジケーターが存在する可能性がある（タイミング次第）
+    // 注：実際のテストでは、モックデータで遅延を制御することが望ましい
+  }
+
+  // MARK: - フレンドの履歴タブテスト
+
+  func testFriendWalkHistoryComingSoon() throws {
+    // Given: フレンドの履歴タブを選択
+    let friendHistoryButton = app.buttons["フレンドの履歴"]
+    friendHistoryButton.tap()
+
+    // When: 近日公開予定のメッセージを確認
+    let comingSoonTitle = app.staticTexts["フレンドの履歴"]
+    let comingSoonMessage = app.staticTexts["友達の散歩履歴は近日公開予定です"]
+
+    // Then: 正しいメッセージが表示される
+    XCTAssertTrue(comingSoonTitle.exists)
+    XCTAssertTrue(comingSoonMessage.exists)
+  }
+
+  func testFriendWalkHistoryIcon() throws {
+    // Given: フレンドの履歴タブを選択
+    let friendHistoryButton = app.buttons["フレンドの履歴"]
+    friendHistoryButton.tap()
+
+    // When: アイコンの存在を確認
+    let friendIcon = app.images.containing(
+      NSPredicate(format: "identifier CONTAINS 'person.2.circle'")
+    ).firstMatch
+
+    // Then: フレンドアイコンが表示される
+    // 注：実際のテストでは、アクセシビリティ識別子を使用することが推奨
+    XCTAssertTrue(friendIcon.exists || app.staticTexts.count > 0)  // フォールバック確認
+  }
+
+  // MARK: - プルトゥリフレッシュテスト
+
+  func testPullToRefreshInMyHistory() throws {
+    // Given: 自分の履歴タブが表示されている
+    let myHistoryButton = app.buttons["自分の履歴"]
+    myHistoryButton.tap()
+
+    // When: プルトゥリフレッシュを実行
+    let scrollView = app.scrollViews.firstMatch
+    if scrollView.exists {
+      scrollView.swipeDown()
     }
-    
-    override func tearDownWithError() throws {
-        app = nil
+
+    // Then: リフレッシュ動作が実行される
+    // 注：実際のテストでは、ネットワーク呼び出しをモックして確認
+    XCTAssertTrue(true)  // プレースホルダー
+  }
+
+  // MARK: - アクセシビリティテスト
+
+  func testAccessibilityElements() throws {
+    // Given: WalkHistoryViewが表示されている
+
+    // When: アクセシビリティ要素を確認
+    let myHistoryButton = app.buttons["自分の履歴"]
+    let friendHistoryButton = app.buttons["フレンドの履歴"]
+
+    // Then: 適切なアクセシビリティプロパティが設定されている
+    XCTAssertTrue(myHistoryButton.isHittable)
+    XCTAssertTrue(friendHistoryButton.isHittable)
+  }
+
+  // MARK: - パフォーマンステスト
+
+  func testWalkHistoryViewLaunchPerformance() throws {
+    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+      // このテストは、WalkHistoryViewを含むタブの起動パフォーマンスを測定します
+      measure(metrics: [XCTApplicationLaunchMetric()]) {
+        XCUIApplication().launch()
+      }
     }
-    
-    // MARK: - 基本ナビゲーションテスト
-    
-    func testWalkHistoryViewBasicNavigation() throws {
-        // Given: アプリが起動している
-        
-        // When: おさんぽタブが表示される
-        let friendTab = app.buttons["おさんぽ"]
-        XCTAssertTrue(friendTab.exists)
-        
-        // Then: おさんぽタブが選択状態になっている
-        XCTAssertTrue(friendTab.isSelected)
-    }
-    
-    func testWalkHistoryViewNavigationTitle() throws {
-        // Given: おさんぽタブが表示されている
-        
-        // When: ナビゲーションタイトルを確認
-        let navigationTitle = app.navigationBars["おさんぽ"]
-        
-        // Then: 正しいタイトルが表示されている
-        XCTAssertTrue(navigationTitle.exists)
-    }
-    
-    // MARK: - セグメントコントロールテスト
-    
-    func testSegmentedControlExists() throws {
-        // Given: WalkHistoryViewが表示されている
-        
-        // When: セグメントコントロールを探す
-        let segmentedControl = app.segmentedControls.firstMatch
-        
-        // Then: セグメントコントロールが存在する
-        XCTAssertTrue(segmentedControl.exists)
-    }
-    
-    func testSegmentedControlOptions() throws {
-        // Given: WalkHistoryViewが表示されている
-        
-        // When: セグメントコントロールのボタンを確認
-        let myHistoryButton = app.buttons["自分の履歴"]
-        let friendHistoryButton = app.buttons["フレンドの履歴"]
-        
-        // Then: 両方のオプションが存在する
-        XCTAssertTrue(myHistoryButton.exists)
-        XCTAssertTrue(friendHistoryButton.exists)
-    }
-    
-    func testSegmentedControlTapping() throws {
-        // Given: WalkHistoryViewが表示されている
-        let myHistoryButton = app.buttons["自分の履歴"]
-        let friendHistoryButton = app.buttons["フレンドの履歴"]
-        
-        // When: 「自分の履歴」が最初に選択されている
-        XCTAssertTrue(myHistoryButton.isSelected)
-        XCTAssertFalse(friendHistoryButton.isSelected)
-        
-        // When: 「フレンドの履歴」をタップ
-        friendHistoryButton.tap()
-        
-        // Then: 選択状態が変更される
-        XCTAssertFalse(myHistoryButton.isSelected)
-        XCTAssertTrue(friendHistoryButton.isSelected)
-        
-        // When: 「自分の履歴」に戻る
-        myHistoryButton.tap()
-        
-        // Then: 元の状態に戻る
-        XCTAssertTrue(myHistoryButton.isSelected)
-        XCTAssertFalse(friendHistoryButton.isSelected)
-    }
-    
-    // MARK: - 自分の履歴タブテスト
-    
-    func testMyWalkHistoryEmptyState() throws {
-        // Given: 自分の履歴タブが選択されている
-        let myHistoryButton = app.buttons["自分の履歴"]
-        myHistoryButton.tap()
-        
-        // When: 空の状態を確認
-        let emptyMessage = app.staticTexts["散歩履歴がありません"]
-        let emptyDescription = app.staticTexts["散歩を完了すると、ここに履歴が表示されます"]
-        
-        // Then: 空の状態メッセージが表示される
-        XCTAssertTrue(emptyMessage.exists)
-        XCTAssertTrue(emptyDescription.exists)
-    }
-    
-    func testMyWalkHistoryLoadingState() throws {
-        // Given: 自分の履歴タブが選択されている
-        let myHistoryButton = app.buttons["自分の履歴"]
-        myHistoryButton.tap()
-        
-        // When: 読み込み状態を確認（短時間のため、すばやく確認）
-        let loadingIndicator = app.activityIndicators.firstMatch
-        
-        // Then: ローディングインジケーターが存在する可能性がある（タイミング次第）
-        // 注：実際のテストでは、モックデータで遅延を制御することが望ましい
-    }
-    
-    // MARK: - フレンドの履歴タブテスト
-    
-    func testFriendWalkHistoryComingSoon() throws {
-        // Given: フレンドの履歴タブを選択
-        let friendHistoryButton = app.buttons["フレンドの履歴"]
-        friendHistoryButton.tap()
-        
-        // When: 近日公開予定のメッセージを確認
-        let comingSoonTitle = app.staticTexts["フレンドの履歴"]
-        let comingSoonMessage = app.staticTexts["友達の散歩履歴は近日公開予定です"]
-        
-        // Then: 正しいメッセージが表示される
-        XCTAssertTrue(comingSoonTitle.exists)
-        XCTAssertTrue(comingSoonMessage.exists)
-    }
-    
-    func testFriendWalkHistoryIcon() throws {
-        // Given: フレンドの履歴タブを選択
-        let friendHistoryButton = app.buttons["フレンドの履歴"]
-        friendHistoryButton.tap()
-        
-        // When: アイコンの存在を確認
-        let friendIcon = app.images.containing(NSPredicate(format: "identifier CONTAINS 'person.2.circle'")).firstMatch
-        
-        // Then: フレンドアイコンが表示される
-        // 注：実際のテストでは、アクセシビリティ識別子を使用することが推奨
-        XCTAssertTrue(friendIcon.exists || app.staticTexts.count > 0) // フォールバック確認
-    }
-    
-    // MARK: - プルトゥリフレッシュテスト
-    
-    func testPullToRefreshInMyHistory() throws {
-        // Given: 自分の履歴タブが表示されている
-        let myHistoryButton = app.buttons["自分の履歴"]
-        myHistoryButton.tap()
-        
-        // When: プルトゥリフレッシュを実行
-        let scrollView = app.scrollViews.firstMatch
-        if scrollView.exists {
-            scrollView.swipeDown()
-        }
-        
-        // Then: リフレッシュ動作が実行される
-        // 注：実際のテストでは、ネットワーク呼び出しをモックして確認
-        XCTAssertTrue(true) // プレースホルダー
-    }
-    
-    // MARK: - アクセシビリティテスト
-    
-    func testAccessibilityElements() throws {
-        // Given: WalkHistoryViewが表示されている
-        
-        // When: アクセシビリティ要素を確認
-        let myHistoryButton = app.buttons["自分の履歴"]
-        let friendHistoryButton = app.buttons["フレンドの履歴"]
-        
-        // Then: 適切なアクセシビリティプロパティが設定されている
-        XCTAssertTrue(myHistoryButton.isHittable)
-        XCTAssertTrue(friendHistoryButton.isHittable)
-    }
-    
-    // MARK: - パフォーマンステスト
-    
-    func testWalkHistoryViewLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // このテストは、WalkHistoryViewを含むタブの起動パフォーマンスを測定します
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
-    }
-    
-    // MARK: - エラーハンドリングテスト
-    
-    func testNetworkErrorHandling() throws {
-        // Given: ネットワークエラーが発生する状況をシミュレート
-        // 注：実際のテストでは、モックネットワーク環境を設定
-        
-        // When: 自分の履歴タブを表示
-        let myHistoryButton = app.buttons["自分の履歴"]
-        myHistoryButton.tap()
-        
-        // Then: エラー状態でも適切にUIが表示される
-        // プレースホルダー：実際のエラーハンドリングUIが実装された後にテストを更新
-        XCTAssertTrue(true)
-    }
+  }
+
+  // MARK: - エラーハンドリングテスト
+
+  func testNetworkErrorHandling() throws {
+    // Given: ネットワークエラーが発生する状況をシミュレート
+    // 注：実際のテストでは、モックネットワーク環境を設定
+
+    // When: 自分の履歴タブを表示
+    let myHistoryButton = app.buttons["自分の履歴"]
+    myHistoryButton.tap()
+
+    // Then: エラー状態でも適切にUIが表示される
+    // プレースホルダー：実際のエラーハンドリングUIが実装された後にテストを更新
+    XCTAssertTrue(true)
+  }
 }


### PR DESCRIPTION
## Summary
- WalkHistoryViewのUIテスト失敗問題を解決
- セグメントコントロールと空の状態表示にアクセシビリティ識別子を追加
- UITestingHelperで新旧両方の起動引数形式をサポート  
- WalkRepositoryでUIテストモード時に空のリストを返す機能を追加

## Test plan
- [x] 既存のUIテストが正常に動作することを確認
- [x] 新しいUITestingHelperが適切に動作することを確認
- [x] WalkRepositoryのUIテストモード対応が正常に動作することを確認
- [x] 13個のUIテストすべてが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)