### PR TITLE
[#103] 散歩一時停止・完了後に歩数表示が消失するバグ

### DIFF
--- a/TokoToko/Model/Services/StepCountManager.swift
+++ b/TokoToko/Model/Services/StepCountManager.swift
@@ -32,7 +32,6 @@ enum StepCountSource {
   /// - Parameter steps: 計測された歩数
   case coremotion(steps: Int)
 
-
   /// 歩数計測が利用不可能な状態
   ///
   /// センサーが利用できない、権限が拒否された、
@@ -357,14 +356,15 @@ class StepCountManager: ObservableObject, CustomDebugStringConvertible {
   /// 歩数のリアルタイムトラッキングを停止
   ///
   /// 現在実行中の歩数トラッキングを安全に停止し、
-  /// 関連する状態をリセットします。
+  /// 関連する状態をリセットします。一時停止時の表示継続のため、
+  /// 歩数データは保持されます。
   ///
   /// ## Cleanup Process
   /// 1. トラッキング状態を確認（停止済みの場合は早期リターン）
   /// 2. CMPedometer.stopUpdates()でセンサーアップデート停止
   /// 3. トラッキング状態をfalseに設定
   /// 4. 開始時刻とベースラインをリセット
-  /// 5. 歩数データをunavailable状態に設定
+  /// 5. 歩数データは保持される（unavailableにリセットしない）
   func stopTracking() {
     guard isTracking else { return }
 
@@ -376,11 +376,7 @@ class StepCountManager: ObservableObject, CustomDebugStringConvertible {
     isTracking = false
     startDate = nil
     baselineSteps = 0
-
-    // 停止時は計測不可状態にリセット
-    updateStepCount(.unavailable)
   }
-
 
   // MARK: - Private Methods
 

--- a/TokoToko/Model/Services/WalkManager.swift
+++ b/TokoToko/Model/Services/WalkManager.swift
@@ -464,15 +464,7 @@ class WalkManager: NSObject, ObservableObject, StepCountDelegate {
     let previousStatus = walk.status.rawValue
 
     // 最終歩数を保存
-    let finalSteps = totalSteps
-    walk.totalSteps = finalSteps
-    
-    #if DEBUG
-      print("📊 散歩終了時の歩数保存: \(finalSteps)歩")
-      print("   - currentStepCount: \(currentStepCount)")
-      print("   - walk.totalSteps: \(walk.totalSteps)")
-    #endif
-    
+    walk.totalSteps = totalSteps
     walk.complete()
     currentWalk = walk
 
@@ -553,7 +545,6 @@ class WalkManager: NSObject, ObservableObject, StepCountDelegate {
       print("エラー: 保存する散歩がありません")
       return
     }
-
 
     walkRepository.saveWalk(walk) { result in
       DispatchQueue.main.async {
@@ -759,16 +750,17 @@ extension WalkManager: LocationUpdateDelegate {
 extension WalkManager {
   /// 歩数カウントが更新された時に呼び出されます
   ///
-  /// CoreMotionからの実際の歩数、または距離・時間からの推定歩数を受け取り、
-  /// UI更新のためにメインスレッドで`currentStepCount`を更新します。
+  /// CoreMotionからの実際の歩数を受け取り、UI更新のためにメインスレッドで
+  /// `currentStepCount`を更新します。散歩記録中の場合は、現在のWalkオブジェクトの
+  /// 歩数も同期的に更新します。
   ///
   /// - Parameter stepCount: 更新された歩数データ
   func stepCountDidUpdate(_ stepCount: StepCountSource) {
     DispatchQueue.main.async { [weak self] in
       guard let self = self else { return }
-      
+
       self.currentStepCount = stepCount
-      
+
       // 散歩中の場合、現在のWalkにも歩数を更新
       if var walk = self.currentWalk, self.isRecording {
         walk.totalSteps = stepCount.steps ?? 0
@@ -778,9 +770,6 @@ extension WalkManager {
       #if DEBUG
         if let steps = stepCount.steps {
           print("📊 歩数更新: \(steps)歩 (\(stepCount.isRealTime ? "実測" : "推定"))")
-          if self.isRecording {
-            print("   - 散歩記録中: walk.totalSteps = \(self.currentWalk?.totalSteps ?? 0)")
-          }
         }
       #endif
     }

--- a/TokoToko/Model/Services/WalkManager.swift
+++ b/TokoToko/Model/Services/WalkManager.swift
@@ -464,7 +464,15 @@ class WalkManager: NSObject, ObservableObject, StepCountDelegate {
     let previousStatus = walk.status.rawValue
 
     // 最終歩数を保存
-    walk.totalSteps = totalSteps
+    let finalSteps = totalSteps
+    walk.totalSteps = finalSteps
+    
+    #if DEBUG
+      print("📊 散歩終了時の歩数保存: \(finalSteps)歩")
+      print("   - currentStepCount: \(currentStepCount)")
+      print("   - walk.totalSteps: \(walk.totalSteps)")
+    #endif
+    
     walk.complete()
     currentWalk = walk
 
@@ -757,11 +765,22 @@ extension WalkManager {
   /// - Parameter stepCount: 更新された歩数データ
   func stepCountDidUpdate(_ stepCount: StepCountSource) {
     DispatchQueue.main.async { [weak self] in
-      self?.currentStepCount = stepCount
+      guard let self = self else { return }
+      
+      self.currentStepCount = stepCount
+      
+      // 散歩中の場合、現在のWalkにも歩数を更新
+      if var walk = self.currentWalk, self.isRecording {
+        walk.totalSteps = stepCount.steps ?? 0
+        self.currentWalk = walk
+      }
 
       #if DEBUG
         if let steps = stepCount.steps {
           print("📊 歩数更新: \(steps)歩 (\(stepCount.isRealTime ? "実測" : "推定"))")
+          if self.isRecording {
+            print("   - 散歩記録中: walk.totalSteps = \(self.currentWalk?.totalSteps ?? 0)")
+          }
         }
       #endif
     }


### PR DESCRIPTION
## 概要

散歩機能において、履歴画面・完了画面・共有画像で歩数表示が正常に行われないバグを修正しました。

## 関連Issue
- Closes #103

## 修正内容

### StepCountManager の修正
- `stopTracking()` メソッドで歩数データを `.unavailable` 状態にリセットしないよう変更
- 一時停止時も歩数表示を継続するよう改善
- ドキュメントコメントを修正し、動作を明確化

### WalkManager の修正
- `stepCountDidUpdate` メソッドで `currentWalk.totalSteps` も同期的に更新
- 散歩記録中の歩数データが確実に保存されるよう改善
- デバッグログの出力も改善

## 影響範囲
- 散歩履歴の歩数表示が正常に動作
- 散歩完了画面での歩数表示が正常に動作  
- 共有画像に歩数情報が正しく含まれる
- 散歩一時停止時も歩数表示が継続

## テスト
- [ ] ユニットテスト実行
- [ ] 手動テスト完了
- [ ] 散歩開始→一時停止→再開→完了の一連の流れで歩数表示が継続される
- [ ] 散歩完了画面で正しい歩数が表示される
- [ ] 散歩履歴画面で過去の散歩の歩数が表示される  
- [ ] 共有画像に歩数情報が含まれる

## チェックリスト
- [x] コードレビュー準備完了
- [x] ドキュメント更新（必要な場合）
- [x] 破壊的変更なし