### PR TITLE
refactor: 実装済み認証機能のTODOコメントを削除

### DIFF
--- a/backend/internal/interface/api/handler/walk_handler.go
+++ b/backend/internal/interface/api/handler/walk_handler.go
@@ -48,7 +48,6 @@ type UpdateWalkRequest struct {
 func (h *WalkHandler) ListWalks(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	// TODO: 認証実装後にuserIDを取得
 	userID := h.getUserID(c)
 
 	// ページネーションパラメータ取得
@@ -84,7 +83,6 @@ func (h *WalkHandler) ListWalks(c *gin.Context) {
 func (h *WalkHandler) GetWalk(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	// TODO: 認証実装後にuserIDを取得
 	userID := h.getUserID(c)
 
 	// IDパラメータ取得
@@ -116,7 +114,6 @@ func (h *WalkHandler) GetWalk(c *gin.Context) {
 func (h *WalkHandler) CreateWalk(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	// TODO: 認証実装後にuserIDを取得
 	userID := h.getUserID(c)
 
 	// リクエストボディをバインド
@@ -148,7 +145,6 @@ func (h *WalkHandler) CreateWalk(c *gin.Context) {
 func (h *WalkHandler) UpdateWalk(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	// TODO: 認証実装後にuserIDを取得
 	userID := h.getUserID(c)
 
 	// IDパラメータ取得
@@ -194,7 +190,6 @@ func (h *WalkHandler) UpdateWalk(c *gin.Context) {
 func (h *WalkHandler) DeleteWalk(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	// TODO: 認証実装後にuserIDを取得
 	userID := h.getUserID(c)
 
 	// IDパラメータ取得


### PR DESCRIPTION
## 概要

Issue #174 で「未実装」とされていた認証機能について調査を実施した結果、**既に完全に実装済み**であることが判明したため、古いTODOコメントをクリーンアップしました。

## 変更内容

### 削除したTODOコメント（5箇所）

`backend/internal/interface/api/handler/walk_handler.go`

```go
// 削除前
// TODO: 認証実装後にuserIDを取得
userID := h.getUserID(c)

// 削除後
userID := h.getUserID(c)
```

**対象メソッド**:
- `ListWalks()` - 散歩一覧取得
- `GetWalk()` - 散歩詳細取得
- `CreateWalk()` - 散歩作成
- `UpdateWalk()` - 散歩更新
- `DeleteWalk()` - 散歩削除

## 認証実装の確認結果

### ✅ 実装済みの機能

| 項目 | 実装箇所 | 状態 |
|------|---------|------|
| AuthMiddleware | `middleware/auth.go` (220行) | ✅ 実装済み |
| VerifyIDToken | Firebase Admin SDK | ✅ 実装済み |
| TokenCache (5分TTL) | `middleware/auth.go` | ✅ 実装済み |
| GetUserID()ヘルパー | `middleware/auth.go` | ✅ 実装済み |
| auth_test.go | `middleware/auth_test.go` (331行) | ✅ 12ケース実装済み |
| Firebase Admin SDK | `go.mod` | ✅ v4.18.0 追加済み |
| ミドルウェア適用 | `router/router.go:70` | ✅ `/v1/walks`グループに適用済み |

### 認証フロー（実装済み）

```
iOS App → Firebase Auth → ID Token発行
  ↓ Authorization: Bearer <token>
AuthMiddleware
  ↓ TokenCache確認（5分TTL）
  ↓ Firebase Admin SDK.VerifyIDToken()
  ↓ gin.Context["userID"] 設定
WalkHandler
  ↓ middleware.GetUserID(c) でユーザーID取得
  ↓ ビジネスロジック実行
```

## テスト結果

### ✅ 認証ミドルウェアテスト（全12ケースパス）

```
PASS: TestTokenCache_SetAndGet
PASS: TestTokenCache_GetNonExistent
PASS: TestTokenCache_Expiration
PASS: TestGetUserID_Success
PASS: TestGetUserID_NotFound
PASS: TestGetUserID_InvalidType
PASS: TestTokenCache_Cleanup
PASS: TestAuthMiddleware_Handler_WithValidToken
PASS: TestAuthMiddleware_Handler_WithInvalidToken
PASS: TestAuthMiddleware_Handler_WithCachedToken
PASS: TestAuthMiddleware_Handler_MissingAuthorizationHeader
PASS: TestAuthMiddleware_Handler_InvalidHeaderFormat
ok (0.491s)
```

### ✅ WalkHandlerテスト（全15ケースパス）

```
PASS: TestWalkHandler_CreateWalk_Success
PASS: TestWalkHandler_GetWalk_Success
PASS: TestWalkHandler_ListWalks_Success
PASS: TestWalkHandler_UpdateWalk_Success
PASS: TestWalkHandler_DeleteWalk_Success
（他10ケース）
ok (0.564s)
```

## 影響範囲

- **機能的な変更**: なし（コメント削除のみ）
- **動作への影響**: なし
- **破壊的変更**: なし

## チェックリスト

- [x] コードベース全体の認証実装状況を調査
- [x] 認証ミドルウェアテストを実行（全パス）
- [x] WalkHandlerテストを実行（全パス）
- [x] TODOコメントを削除
- [x] Issue #174 に調査結果を報告

## 関連Issue

close #174

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)